### PR TITLE
added comments, updated variable names and now returns EODs sorted by…

### DIFF
--- a/thunderfish/lizpulses.py
+++ b/thunderfish/lizpulses.py
@@ -1,21 +1,516 @@
+"""
+# Extract pulse-type weakly electric fish
+Extract all timepoints where pulsefish EODs are present for each separate pulsefish in a recording.
+
+# Main function
+- `extract_pulsefish()`: checks for pulse-type fish based on the EOD amplitude and shape.
+
+Author: Liz Weerdmeester
+Email: weerdmeester.liz@gmail.com
+
+"""
 import numpy as np
 import matplotlib.pyplot as plt
+from scipy import stats
 
 from sklearn.preprocessing import StandardScaler
 from sklearn.decomposition import PCA
 from sklearn.cluster import DBSCAN
-from sklearn.mixture import GaussianMixture, BayesianGaussianMixture
-from sklearn.metrics import pairwise_distances, silhouette_score
+from sklearn.mixture import BayesianGaussianMixture
+from sklearn.metrics import pairwise_distances
 
 from .eventdetection import detect_peaks
 from .pulse_tracker_helper import makeeventlist, discardnearbyevents, discard_connecting_eods
 
-
-# upgrade numpy fumctions:
-
+# upgrade numpy fumctions for backwards compatebility:
 if not hasattr(np, 'isin'):
     np.isin = np.in1d
 
+def extract_pulsefish(data, samplerate, peakwidth=0.002, cutwidth=0.001, **cluster_kwargs):
+    """
+    Takes recording data containing an unknown number of pulsefish and extracts the mean 
+    EOD and EOD timepoints for each fish present in the recording.
+    
+    Parameters
+    ----------
+    data: 1-D array of float
+        The data to be analysed.
+    samplerate: float
+        Sampling rate of the data in Hertz.
+    peakwidth: float (optional)
+        Peakwidth for peak detection in seconds.
+    cutwidth: float (optional)
+        Width for extracting snippets for clustering based on EOD shape.
+    **cluster_kwargs: (optional) 
+        keyword arguments for clustering parameters (see 'cluster()')
+        
+    Returns
+    -------
+    mean_eods: list of 2D arrays
+        The average EOD for each detected fish. First column is time in seconds,
+        second column the mean eod, third column the standard error.
+    eod_times: list of 1D arrays
+        For each detected fish the times of EOD peaks in seconds.
+    eod_unreliability: list of floats
+        For each detected fish, the unreliability score, where scores > 0.1
+        signify unreliable EOD means (possibly wavefish or unreliable clusters).
+    """
+    
+    mean_eods, eod_times, eod_unreliability = [], [], []
+    
+    # extract peaks
+    x_peak, x_trough, eod_hights, eod_widths = extract_eod_times(data, peakwidth*samplerate,cutwidth*samplerate)
+
+    if len(x_peak)>0:
+
+        # cluster on peaks
+        peak_clusters = cluster(x_peak, eod_hights, eod_widths, data, samplerate, cutwidth, **cluster_kwargs) 
+
+        # cluster on troughs
+        trough_clusters = cluster(x_trough, eod_hights, eod_widths, data, samplerate, cutwidth, **cluster_kwargs)
+
+        # merge peak and trough clusters
+        clusters, x_merge = merge_clusters(peak_clusters, trough_clusters, x_peak, x_trough)
+
+        # remove noise from merged clusters
+        clusters = remove_noise_and_artefacts(data, x_merge, eod_widths, clusters, int(cutwidth*samplerate))
+
+        # delete the moving fish
+        clusters = delete_moving_fish(clusters, x_merge/samplerate, len(data)/samplerate, eod_hights)
+
+        # extract mean eods
+        mean_eods, eod_times, eod_unreliability = find_window(data, x_merge, eod_widths, clusters, samplerate)
+    
+    return mean_eods, eod_times, eod_unreliability
+
+
+def extract_eod_times(data, peakwidth, cutwidth, threshold_factor=2):
+    """
+    Extract peaks from data which are potentially EODs.
+
+    Parameters
+    ----------
+    data: 1-D array of float
+        The data to be analysed.
+    peakwidth: int
+        Peakwidth for peak detection in samples.
+    cutwidth: int
+        Width for extracting snippets for clustering based on EOD shape in samples.
+    threshold_factor: float (optional)
+        Multiplication factor for peak detection threshold.
+
+    Returns
+    -------
+    x_peak: array of ints
+        Indices of EOD peaks in data.
+    x_trough: array of ints
+        Indices of EOD troughs in data. There is one x_trough for each x_peak.
+    eod_hights: array of floats
+        EOD hights for each x_peak.
+    eod_widths: array of ints
+        EOD widths for each x_peak (in samples).
+    """
+    
+    threshold = np.mean(np.abs(data))*threshold_factor
+    x_peaks, x_troughs = detect_peaks(data, threshold)
+
+    if len(x_peaks)==0:
+        return [], [], [], []
+    else:
+        peaks = makeeventlist(x_peaks,x_troughs,data,peakwidth)
+        peakindices, _, _ = discardnearbyevents(peaks[0],peaks[3],peakwidth)
+        x_peaks, x_troughs, eod_hights, eod_widths = discard_connecting_eods(peaks[0][peakindices], peaks[1][peakindices], peaks[3][peakindices], peaks[4][peakindices])
+        
+        # only take those where the cutwidth does not casue issues
+        cut_idx = np.where((x_peaks>int(cutwidth/2)) & (x_peaks<(len(data)-int(cutwidth/2))) & (x_troughs>int(cutwidth/2)) & (x_troughs<(len(data)-int(cutwidth/2))))[0]
+
+        return x_peaks[cut_idx], x_troughs[cut_idx], eod_hights[cut_idx], eod_widths[cut_idx]
+
+
+def cluster(eod_x, eod_hights, eod_widths, data, samplerate, cutwidth, minp=10, percentile=75, n_pc=3, n_gaus=4, n_init=1, max_iter=200, subtract_slope=False):
+    """
+    Cluster EODs. First cluster on EOD hights using a Bayesian Gaussian Mixture model, 
+    then cluster on EOD waveform with DBSCAN. Clustering on EOD waveform is performed
+    twice, once on scaled EODs and once on non-scaled EODs. Clusters are merged afterwards.
+
+    Parameters
+    ----------
+    eod_x: list of ints
+        Locations of EODs in samples.
+    eod_hights: list of floats
+        EOD hights.
+    eod_widths: list of ints
+        EOD widths in samples.
+    data: list of floats
+        Raw recording data.
+    samplerate : int or float
+        Sample rate of raw data.
+    cutwidth: float
+        Width for extracting snippets for clustering based on EOD shape.
+    minp (optional): int
+        Minimun number of points for core cluster (DBSCAN).
+        Defaults to 10.
+    percentile (optional): float
+        Percentile for determining epsilon from knn distribution where k=minp.
+        Defaults to 75.
+    n_pc (optional): int
+        Number of PCs to use for PCA.
+        Defaults to 3.
+    n_gaus (optional): int
+        Maximun number of gaussians to fit for clustering on EOD hights.
+        Defaults to 4.
+    n_init (optional): int
+        Number of initializations for BayesianGaussianMixture method. 
+        Increase for improved accuracy, decrease for improved computation speed.
+        Defaults to 1.
+    max_iter (optional): int
+        Maximum number of iterations for BayesianGausssianMixture method.
+    subtract_slope (optional): boolean
+        If True, subtract slope to improve clustering for pulse EODs superimposed on slow wavefish.
+        Defaults to False, as method is still being tested.
+
+    Returns
+    -------
+    labels : list of ints
+        EOD cluster labels based on hight and EOD waveform.
+
+    """
+
+    # initiate labels based on hight
+    hight_labels = np.ones(eod_hights.shape)
+    
+    if ((np.max(eod_hights) - np.min(eod_hights))/np.max(eod_hights)) > 0.25:
+
+        # classify by height
+        BGM_model = BayesianGaussianMixture(n_gaus,max_iter=max_iter,n_init=n_init)
+        hight_labels = BGM_model.fit_predict(eod_hights.reshape(-1,1))
+
+        # if any of the clusters merged have very little height difference, merge them.
+        if len(np.unique(hight_labels))>1:
+            for hight_label in np.unique(hight_labels):
+                if ((np.max(eod_hights[hight_labels!=hight_label]) - np.min(eod_hights[hight_labels!=hight_label]))/np.max(eod_hights[hight_labels!=hight_label])) < 0.25:
+                    hight_labels[hight_labels!=hight_label] = np.max(hight_labels) + 1
+
+    # now cluster based on waveform
+    labels = np.ones(len(hight_labels))*-1    
+        
+    # extract snippets
+    snippets = np.vstack([data[int(x-cutwidth*samplerate/2):int(x+cutwidth*samplerate/2)] for x in eod_x]) 
+    
+    if subtract_slope:
+        snippets = subtract_slope(snippets)
+    
+    # keep track of the labels so that no labels are overwritten
+    max_label = 0
+            
+    for hight_label in np.unique(hight_labels):
+        if len(hight_labels[hight_labels==hight_label]) > minp:
+
+            # extract snippets, idxs and hs for this hight cluster
+            current_snippets = StandardScaler().fit_transform(snippets[hight_labels==hight_label])
+            
+            # extract relevant snippet features
+            features = PCA(n_pc).fit(current_snippets).transform(current_snippets)
+            
+            # determine good epsilon for DBSCAN  
+            knn = np.sort(pairwise_distances(features,features))[:,minp]        
+            eps = np.percentile(knn,percentile)
+
+            # cluster by EOD shape
+            clusters_scaled = DBSCAN(eps=eps, min_samples=minp).fit(features).labels_
+
+            # remove noise and artefacts from clusters
+            clusters_scaled = remove_noise_and_artefacts(data, eod_x[hight_labels==hight_label], 
+                eod_widths[hight_labels==hight_label], clusters_scaled, int(cutwidth*samplerate))
+
+            # cluster again without scaling (sometimes this works better wrt scaling)
+            current_snippets = snippets[hight_labels==hight_label]
+            features = PCA(n_pc).fit(current_snippets).transform(current_snippets)
+            knn = np.sort(pairwise_distances(features,features))[:,minp]        
+            eps = np.percentile(knn,percentile)
+            clusters_unscaled = DBSCAN(eps=eps, min_samples=minp).fit(features).labels_
+            clusters_unscaled = remove_noise_and_artefacts(data, eod_x[hight_labels==hight_label], 
+                eod_widths[hight_labels==hight_label], clusters_unscaled, int(cutwidth*samplerate))              
+
+            # merge results for scaling and without scaling
+            clusters, _ = merge_clusters(clusters_scaled,clusters_unscaled,eod_x[hight_labels==hight_label],
+                eod_x[hight_labels==hight_label])
+
+            # remove noise after merging
+            clusters = remove_noise_and_artefacts(data, eod_x[hight_labels==hight_label], eod_widths[hight_labels==hight_label],
+                clusters, int(cutwidth*samplerate))
+
+            # update maxlab so that no clusters are overwritten
+            clusters[clusters==-1] = -max_label - 1
+            labels[hight_labels==hight_label] = clusters + max_label
+            max_label = np.max(labels) + 1
+
+    # return the cluster labels             
+    return labels
+
+
+def find_window(data,eod_x,eod_widths,clusters,samplerate,w_factor=4):
+    """
+    Extract mean EODs, EOD timepoints and unreliability score for each EOD cluster.
+
+    Parameters
+    ----------
+        data: list of floats
+            Raw recording data.
+        eod_x: list of ints
+            Locations of EODs in samples.
+        eod_widths: list of ints
+            EOD widths in samples.
+        clusters: list of ints
+            EOD cluster labels
+        samplerate: float
+            samplerate of recording                
+        w_factor (optional): float
+            Multiplication factor for window used to extract noise and artefacts.
+            Defaults to 4.
+
+    Returns
+    -------
+        mean_eods: list of 2D arrays
+            The average EOD for each detected fish. First column is time in seconds,
+            second column the mean eod, third column the standard error.
+        eod_times: list of 1D arrays
+            For each detected fish the times of EOD peaks in seconds.
+        unreliability: list of floats
+            Measure of unreliability of extracted fish. Numbers above 0.1 indicate 
+            wavefish or unreliable pulsefish clusters.
+    """
+
+    mean_eods, eod_times, eod_hights = [],[],[]
+    unreliability = []
+
+    for cluster in np.unique(clusters):
+        if cluster!=-1:
+            cutwidth = np.mean(eod_widths[clusters==cluster])*w_factor
+            current_x = eod_x[(eod_x>cutwidth) & (eod_x<(len(data)-cutwidth))]
+            current_clusters = clusters[(eod_x>cutwidth) & (eod_x<(len(data)-cutwidth))]
+
+            snippets = np.vstack([data[int(x-cutwidth):int(x+cutwidth)] for x in current_x[current_clusters==cluster]])
+            mean_eod = np.mean(snippets,axis=0)
+            eod_time = np.arange(len(mean_eod))/samplerate - cutwidth/samplerate
+
+            mean_eod = np.vstack([eod_time,mean_eod,np.std(snippets,axis=0)])
+
+            mean_eods.append(mean_eod)
+            eod_times.append(eod_x[clusters==cluster]/samplerate)
+            eod_hights.append(np.min(mean_eod)-np.max(mean_eod))
+            
+            unreliability.append(np.max(np.median(eod_widths[clusters==cluster])/np.diff(eod_x[cluster==clusters])))
+    
+    return [m for _,m in sorted(zip(eod_hights,mean_eods))], [t for _,t in sorted(zip(eod_hights,eod_times))], [ur for _,ur in sorted(zip(eod_hights,unreliability))]
+
+    
+def remove_noise_and_artefacts(data,eod_x,eod_widths,clusters,original_cutwidth,w_factor=2,noise_threshold=0.003,artefact_threshold=0.8):
+    """
+    remove EOD clusters that are too noisy or result from artefacts
+
+    Parameters
+    ----------
+        data: list of floats
+            Raw recording data.
+        eod_x: list of ints
+            Locations of EODs in samples.
+        eod_widths: list of ints
+            EOD widths in samples.
+        clusters: list of ints
+            EOD cluster labels
+        original_cutwidth : int
+            Width that was used for feature extraction.
+        w_factor (optional): float
+            Multiplication factor for windowsize to use for noise and artefact detection.
+            Defaults to 2.
+
+        noise_threshold (optional): float
+            Threshold that separates noisy clusters from clean clusters.
+            Defaults to 0.003.
+        artefact_threshold (optional): float
+            Threshold that separates artefact from clean pulsefish clusters.
+            Defaults to 0.8.
+
+    Returns
+    -------
+        clusters: list of ints
+            Cluster labels, where noisy cluster and clusters with artefacts have been set to zero.
+    """
+
+    for cluster in np.unique(clusters):
+        if cluster!=-1:
+
+            cutwidth = np.max([np.mean(eod_widths[clusters==cluster])*w_factor,int(original_cutwidth/2)])
+
+            # extract snippets
+            current_x = eod_x[(eod_x>cutwidth) & (eod_x<(len(data)-cutwidth))]
+            current_clusters = clusters[(eod_x>cutwidth) & (eod_x<(len(data)-cutwidth))]
+
+            snippets = np.vstack([data[int(x-cutwidth):int(x+cutwidth)] for x in current_x[current_clusters==cluster]])
+
+            mean_eod = np.mean(snippets,axis=0)
+            eod_std = np.std(snippets,axis=0)
+            noise_ratio = np.var(mean_eod)/np.mean(eod_std)
+
+            cut_fft = int(len(np.fft.fft(mean_eod))/2)
+            low_frequency_ratio = np.sum(np.abs(np.fft.fft(mean_eod))[1:int(cut_fft/2)])/np.sum(np.abs(np.fft.fft(mean_eod))[1:int(cut_fft)])
+
+            if noise_ratio < noise_threshold:
+                clusters[clusters==cluster] = -1
+            elif low_frequency_ratio < artefact_threshold:
+                clusters[clusters==cluster] = -1
+
+    return clusters
+
+def merge_clusters(clusters_1, clusters_2, x_1, x_2): 
+    """
+    Merge clusters resulting from two clustering methods. This method only works 
+    if clustering is performed on the same EODs with the same ordering, where there 
+    is a one to one mapping from clusters_1 to clusters_2. 
+
+    Parameters
+    ----------
+        clusters_1: list of ints
+            EOD cluster labels for cluster method 1.
+        clusters_2: list of ints
+            EOD cluster labels for cluster method 2.
+        x_1: list of ints
+            Indices of EODs for cluster method 1 (clusters_1).
+        x_2: list of ints
+            Indices of EODs for cluster method 2 (clusters_2).
+
+    Returns
+    -------
+        clusters : list of ints
+            Merged clusters.
+        x_merged : list of ints
+            Merged cluster indices.
+    """
+
+    # these arrays become 1 for each EOD that is chosen from that array
+    c1_keep = np.zeros(len(clusters_1))
+    c2_keep = np.zeros(len(clusters_2))
+
+    # add n to one of the cluster lists to avoid overlap
+    clusters_2[clusters_2!=-1] = clusters_2[clusters_2!=-1] + np.max(clusters_1) + 1
+    
+    # loop untill done
+    while True:
+
+        # compute unique clusters and cluster sizes
+        # of cluster that have not been iterated over
+        c1_labels, c1_size = unique_counts(clusters_1[(clusters_1!=-1) & (c1_keep == 0)])
+        c2_labels, c2_size = unique_counts(clusters_2[(clusters_2!=-1) & (c2_keep == 0)])
+
+        # if all clusters are done, break from loop
+        if len(c1_size) == 0 and len(c2_size) == 0:
+            break
+
+        # if the biggest cluster is in c_p, keep this one and discard all clusters on the same indices in c_t
+        elif np.argmax([np.max(np.append(c1_size,0)), np.max(np.append(c2_size,0))]) == 0:
+            
+            # remove all the mappings from the other indices
+            cluster_mappings, _ = unique_counts(clusters_2[clusters_1==c1_labels[np.argmax(c1_size)]])
+            
+            clusters_2[np.isin(clusters_2,cluster_mappings)] = -1
+            
+            c1_keep[clusters_1==c1_labels[np.argmax(c1_size)]] = 1
+
+        # if the biggest cluster is in c_t, keep this one and discard all mappings in c_p
+        elif np.argmax([np.max(np.append(c1_size,0)), np.max(np.append(c2_size,0))]) == 1:
+            
+            # remove all the mappings from the other indices
+            cluster_mappings, _ = unique_counts(clusters_1[clusters_2==c2_labels[np.argmax(c2_size)]])
+            
+            clusters_1[np.isin(clusters_1,cluster_mappings)] = -1
+
+            c2_keep[clusters_2==c2_labels[np.argmax(c2_size)]] = 1
+
+    # combine results    
+    clusters = (clusters_1+1)*c1_keep + (clusters_2+1)*c2_keep - 1
+    x_merged = (x_1)*c1_keep + (x_2)*c2_keep
+
+    return clusters, x_merged
+
+
+def delete_moving_fish(clusters, eod_t, T, eod_hights, dt=1, stepsize=0.1, min_eod_factor=1):
+    """
+    Use a sliding window to detect the minimum number of fish detected simultaneously, 
+    then delete all other EOD clusters.
+
+    Parameters
+    ----------
+        clusters: list of ints
+            EOD cluster labels.
+        eod_t: list of floats
+            Timepoints of the EODs (in seconds).
+        T: float
+            Length of recording (in seconds).
+        eod_hights: list of floats
+            EOD amplitudes.
+        dt (optional): float
+            Sliding window size (in seconds).
+        stepsize (optional): float
+            Sliding window stepsize (in seconds).
+        N (optional): int
+            Minimum cluster size.
+
+    Returns
+    -------
+        clusters: list of ints
+            Cluster labels, where deleted clusters have been set to -1.
+    """
+
+    # initialize variables
+    min_clusters = 100
+    average_hight = 0
+    keep_clusters = []
+
+    # only compute on clusters with minimum length.
+    labels, size = unique_counts(clusters)
+    remove_clusters = np.isin(clusters,labels[size<T*min_eod_factor])
+    clusters[remove_clusters] = -1
+
+    # sliding window
+    for t in np.arange(0,T-dt+stepsize,stepsize):
+        current_clusters = clusters[(eod_t>=t)&(eod_t<t+dt)&(clusters!=-1)]
+        if len(np.unique(current_clusters)) <= min_clusters:
+            
+            # only update keep_clus if min_clus is less than the last save
+            # or equal but the hights are higher.
+            current_labels = np.isin(clusters,np.unique(current_clusters))
+            current_hight = np.mean(eod_hights[current_labels])
+
+            if (current_hight > average_hight) or (len(np.unique(current_clusters)) < min_clusters):
+                keep_clusters = np.unique(current_clusters)
+                min_clusters = len(np.unique(current_clusters))
+                average_hight = current_hight
+
+    # delete all clusters that are not selected
+    clusters[np.invert(np.isin(clusters,keep_clusters))] = -1
+
+    return clusters
+
+def subtract_slope(snippets):
+    """
+    Subtract underlying slope from all EOD snippets.
+    Method still under revision.
+
+    Parameters
+    ----------
+        snippets: 2-D numpy array
+            All EODs in a recorded stacked as snippets. 
+            Shape = (number of EODs, EOD width)
+    Returns
+    -------
+        snippets: 2-D numpy array
+            EOD snippets with underlying slope subtracted.
+    """
+    left_y = snippets[:,0]
+    right_y = snippets[:,-1]
+    slopes = np.linspace(left_y,right_y,snippets.shape[1])
+    return snippets - slopes.T
 
 def unique_counts(ar):
     """
@@ -33,451 +528,3 @@ def unique_counts(ar):
         mask[1:] = ar[1:] != ar[:-1]
         idx = np.concatenate(np.nonzero(mask) + ([mask.size],))
         return ar[mask], np.diff(idx)  
-
-
-def extract_eod_times(data,peakwidth,cw,tf=2):
-    '''
-    Extract peaks from data which could be EODs.
-
-    Input
-    -------------------------------------------
-    data: list of floats
-        data to extract peaks from
-    peakwidth: int
-        maximum peakwidth for extracting single EODs
-    cw: int
-        cutwidth. Do not return peak indices that are don't
-        allow full extraction of this EOD waveform
-
-    Returns
-    --------------------------------------------
-    x_peak:     array of ints
-        indices of peaks in data
-    x_trough:   array of ints
-        indices of troughs in data for each x_peak
-    eod_hight:  array of floats
-        EOD hights for each x_peak
-    eod_width:  array of ints
-        EOD widths for each x_peak (in samples)
-    '''
-    
-    # make this std and make 2 a factor.
-    #thresh = np.std(data)*tf
-    thresh = np.mean(np.abs(data))*tf
-    pk, tr = detect_peaks(data, thresh)
-
-    if len(pk)==0:
-        return [], [], [], []
-    else:
-        peaks = makeeventlist(pk,tr,data,peakwidth)
-        peakindices, _, _ = discardnearbyevents(peaks[0],peaks[2],peakwidth)
-        pk, tr, hs, ws = discard_connecting_eods(peaks[0][peakindices.astype('int')].astype('int'), peaks[-1][peakindices.astype('int')].astype('int'), peaks[2][peakindices.astype('int')], peaks[3][peakindices.astype('int')])
-        
-        # only take those where the cutwidth does not casue issues
-        i = np.where((pk>int(cw/2)) & (pk<(len(data)-int(cw/2))) & (tr>int(cw/2)) & (tr<(len(data)-int(cw/2))))[0]
-
-        return pk[i], tr[i], hs[i], ws[i]
-
-
-def cluster(idx_arr,h_arr,w_arr,data,samplerate,cw,minp,percentile,npc,ngaus,n_init,m_iter=100):
-    '''
-    Cluster EODs. First cluster on EOD hights using a Bayesian Gaussian Mixture model, 
-    then cluster on EOD wave shape using DBSCAN.
-
-    Input
-    ------------
-    idx_arr : list of ints
-        locations of EODs (as indices)
-    h_arr : list of floats
-        EOD hights
-    w_arr: list of ints
-        EOD widths
-    data : list of floats
-        raw recording data
-    samplerate : int or float
-        sample rate of raw data
-
-    Parameters
-    -----------------
-    cw : float
-        cut width for extracting snippets for clustering based on EOD shape
-    percentile: float
-        percentile for determining epsilon from knn distribution where k=minp
-    npc : int
-        number of PCs to use for PCA
-    minp : int
-        minimun number of point for core cluster (DBSCAN)
-    ngaus : int
-        maximun number of gaussians to fit for clustering on EOD hights
-    n_init: int
-        number of initializations for BayesianGaussianMixture method
-    m_iter: int
-        maximum number of iterations for BayesianGausssianMixture method
-
-    Returns
-    -------------------
-    al : list of ints
-        EOD cluster labels based on hight and EOD waveform 
-
-    '''
-
-    # initiate labels based on hight
-    l = np.ones(h_arr.shape)
-    
-    if ((np.max(h_arr) - np.min(h_arr))/np.max(h_arr)) > 0.25:
-
-        # classify by height
-        bgm = BayesianGaussianMixture(ngaus,max_iter=m_iter,n_init=n_init)
-        l = bgm.fit_predict(h_arr.reshape(-1,1))
-
-        # if any of the clusters merged have very little height difference, merge them.
-        if len(np.unique(l))>1:
-            for ll in np.unique(l):
-                if ((np.max(h_arr[l!=ll]) - np.min(h_arr[l!=ll]))/np.max(h_arr[l!=ll])) < 0.25:
-                    l[l!=ll] = np.max(l)+1
-
-    # now cluster based on waveform
-    al = np.ones(len(l))*-1    
-        
-    # extract snippets
-    snippets = np.vstack([data[int(idx-cw*samplerate/2):int(idx+cw*samplerate/2)] for idx in idx_arr]) 
-    
-    # keep track of the labels so that no labels are overwritten
-    maxlab = 0
-            
-    for hl in np.unique(l):
-        if len(l[l==hl])>minp:
-
-            # extract snippets, idxs and hs for this hight cluster
-            csnippets = StandardScaler().fit_transform(snippets[l==hl])
-            
-            # extract relevant snippet features
-            pca = PCA(npc).fit(csnippets).transform(csnippets)
-            
-            # determine good epsilon  
-            knn = np.sort(pairwise_distances(pca,pca))[:,minp]        
-            eps = np.percentile(knn,percentile)
-
-            # cluster by EOD shape
-            c = DBSCAN(eps=eps, min_samples=minp).fit(pca).labels_
-
-            # cluster again without scaling (sometimes this works better wrt scaling)
-            csnippets_ns = snippets[l==hl]
-            pca = PCA(npc).fit(csnippets_ns).transform(csnippets_ns)
-            knn = np.sort(pairwise_distances(pca,pca))[:,minp]        
-            eps = np.percentile(knn,percentile)
-            c_ns = DBSCAN(eps=eps, min_samples=minp).fit(pca).labels_
-
-            # remove noise and artefacts from ns clusters
-            c_ns = remove_noise_and_artefacts(data,idx_arr[l==hl],w_arr[l==hl],c_ns,int(cw*samplerate))
-            # remove noise and artefacts from scaled clusters
-            c = remove_noise_and_artefacts(data,idx_arr[l==hl],w_arr[l==hl],c,int(cw*samplerate))
-              
-            # merge results for scaling and without scaling
-            c, _ = merge_clusters(c,c_ns,idx_arr[l==hl],idx_arr[l==hl])
-
-            # remove noise after merging
-            c = remove_noise_and_artefacts(data,idx_arr[l==hl],w_arr[l==hl],c,int(cw*samplerate))
-
-            # update maxlab so that no clusters are overwritten
-            c[c==-1] = -maxlab-1
-            al[l==hl] = c + maxlab
-            maxlab = np.max(al)+1
-
-    # return the overall clusters (al) and the clusters based on hight (l)                
-    return al
-
-
-def find_window(data,idx_arr,w_arr,c,samplerate):
-    '''
-    Select window for extracting mean EODs
-
-    Input
-    --------------
-        data : list of floats
-            raw recording data
-        idx_arr : list of ints
-            EOD indices
-        w_arr : list of ints
-            EOD widths
-        c : list of ints
-            EOD cluster labels
-        samplerate : float
-            samplerate of recording                
-
-    Output
-    --------------
-        mean_eods: list of 2D arrays
-            For each detected fish the average of the EOD snippets. First column is time in seconds,
-            second column the mean eod, third column the standard error.
-        eod_times: list of 1D arrays
-            For each detected fish the times of EOD peaks in seconds.
-    '''
-
-    ms,ts = [],[]
-
-    for l in np.unique(c):
-        if l!=-1:
-            cw = np.mean(w_arr[c==l])*4
-            c_i = idx_arr[(idx_arr>cw) & (idx_arr<(len(data)-cw))]
-            cc = c[(idx_arr>cw) & (idx_arr<(len(data)-cw))]
-
-            w = np.vstack([data[int(idx-cw):int(idx+cw)] for idx in c_i[cc==l]])
-            m = np.mean(w,axis=0)
-            
-            t = np.arange(len(m))/samplerate - cw/samplerate
-            m = np.vstack([t,m,np.std(w,axis=0)])
-
-            ms.append(m)
-            ts.append(idx_arr[c==l]/samplerate)
-                
-    return ms, ts
-
-    
-def remove_noise_and_artefacts(data,idx_arr,w_arr,c,o_cw,nt=0.003,at=0.8):
-    '''
-    remove EOD clusters that are too noisy or result from artefacts
-
-    Input
-    --------------
-        data : list of floats
-            raw recording data
-        idx_arr : list of ints
-            EOD indices
-        w_arr : list of ints
-            EOD widths
-        c : list of ints
-            EOD cluster labels
-        o_cw : int
-            original cutwidth that was used for feature extraction
-
-    Parameters
-    ---------------
-        nt : float
-            noise threshold
-        at : float
-            artefact threshold
-
-    Output
-    --------------
-        c : list of ints
-            cluster labels, where noisy cluster and 
-            clusters with artefacts have been set to zero
-    '''
-
-    for cc in np.unique(c):
-        if cc!=-1:
-
-            cw = np.max([np.mean(w_arr[c==cc])*2,int(o_cw/2)])
-
-            # extract snippets
-            c_i = idx_arr[(idx_arr>cw) & (idx_arr<(len(data)-cw))]
-            cur_c = c[(idx_arr>cw) & (idx_arr<(len(data)-cw))]
-
-            snippets = np.vstack([data[int(idx-cw):int(idx+cw)] for idx in c_i[cur_c==cc]])
-
-            m = np.mean(snippets,axis=0)
-            v = np.std(snippets,axis=0)
-            r = np.var(m)/np.mean(v)
-            stop = int(len(np.fft.fft(m))/2)
-
-            if r<nt:
-                c[c==cc] = -1
-            elif np.sum(np.abs(np.fft.fft(m))[1:int(stop/2)])/np.sum(np.abs(np.fft.fft(m))[1:int(stop)]) < at:
-                c[c==cc] = -1
-
-    return c
-
-
-def merge_clusters(c_p,c_t,idx_arr,idx_t_arr): 
-    '''
-    merge clusters of two clustering methods
-
-    Input
-    --------------
-        c_p : list of ints
-            EOD cluster labels for cluster method 1.
-        c_t : list of ints
-            EOD cluster labels for cluster method 2.
-        idx_arr : list of ints
-            indices of EODs for cluster method 1 (c_p)
-        idx_t_arr : list of ints
-            indices of EODs for cluster method 2 (c_t)
-
-    Output
-    --------------
-        c : list of ints
-            merged clusters
-        idx_arr : list of ints
-            merged cluster indices
-    '''
-
-    # these arrays become 1 for each EOD that is chosen from that array
-    c_pd = np.zeros(len(c_p))
-    c_td = np.zeros(len(c_t))
-
-    # add n to one of the cluster lists to avoid overlap
-    c_t[c_t!=-1] = c_t[c_t!=-1] + np.max(c_p) + 1
-    
-    # loop untill done
-    while True:
-
-        # compute unique clusters and cluster sizes
-        # of cluster that have not been iterated over
-        cu_p, clen_p = unique_counts(c_p[(c_p!=-1) & (c_pd == 0)])
-        cu_t, clen_t = unique_counts(c_t[(c_t!=-1) & (c_td == 0)])
-
-        # if all clusters are done, break from loop
-        if len(clen_p) == 0 and len(clen_t) == 0:
-            break
-
-        # if the biggest cluster is in c_p, keep this one and discard all clusters on the same indices in c_t
-        elif np.argmax([np.max(np.append(clen_p,0)), np.max(np.append(clen_t,0))]) == 0:
-            # remove all the mappings from the other indices
-            cm,ccount = unique_counts(c_t[c_p==cu_p[np.argmax(clen_p)]])
-            for ccm in cm:
-                c_t[c_t==ccm] = -1
-            c_pd[c_p==cu_p[np.argmax(clen_p)]] = 1
-
-        # if the biggest cluster is in c_t, keep this one and discard all mappings in c_p
-        elif np.argmax([np.max(np.append(clen_p,0)), np.max(np.append(clen_t,0))]) == 1:
-            cm, ccount = unique_counts(c_p[c_t==cu_t[np.argmax(clen_t)]])
-            for ccm in cm:
-                c_p[c_p==ccm] = -1
-            c_td[c_t==cu_t[np.argmax(clen_t)]] = 1
-
-    # combine results    
-    c = (c_p+1)*c_pd + (c_t+1)*c_td - 1
-    idx_arr = (idx_arr)*c_pd + (idx_t_arr)*c_td
-
-    return c, idx_arr
-
-
-def delete_moving_fish(c, ts, T, h_arr, dt=1, stepsize=0.1, N=8):
-    '''
-    Use a sliding window to detect the minimum number of fish detected simultaneously.
-    Then delete all other EOD detections.
-
-    Input
-    --------------
-        c : list of ints
-            EOD cluster labels
-        ts : list of floats
-            timepoints of the EODs (in seconds)
-        T : float
-            length of recording (in seconds)
-        h_arr : list of floats
-            EOD amplitudes
-    Parameters
-    ------------------------------
-        dt : float
-            sliding window size (in seconds)
-        stepsize : float
-            sliding window stepsize (in seconds)
-        N : int
-            minimum cluster size
-
-    Output
-    --------------
-        c : list of ints
-            clusters, where deleted clusters have been set to -1
-    '''
-
-    # initialize variables
-    min_clus = 100
-    av_hight = 0
-    keep_clus = []
-
-    # only compute on clusters with minimum length of length N.
-    u,uc = unique_counts(c)
-    m = np.isin(c,u[uc<N])
-    c[m] = -1
-
-    # sliding window
-    for t in np.arange(0,T-dt+stepsize,stepsize):
-        current_clusters = c[(ts>=t)&(ts<t+dt)&(c!=-1)]
-        if len(np.unique(current_clusters)) <= min_clus:
-            
-            # only update keep_clus if min_clus is less than the last save
-            # or equal but the hights are higher.
-            mask = np.isin(c,np.unique(current_clusters))
-            c_hight = np.mean(h_arr[mask])
-
-            if (c_hight > av_hight) or (len(np.unique(current_clusters)) < min_clus):
-                keep_clus = np.unique(current_clusters)
-                min_clus = len(np.unique(current_clusters))
-                av_hight = c_hight
-
-    # delete all clusters that are not selected
-    for cc in np.unique(c):
-        if cc not in keep_clus:
-            c[c==cc] = -1
-
-    return c
-
-
-def extract_pulsefish(data, samplerate, pw=0.002, cw=0.001, percentile=75, npc=3, minp=10, ngaus=4, n_init=1, m_iter=1000):
-    """
-    Takes recording data containing one or more pulsefish 
-    and extracts the mean EOD for each fish present in the recording.
-    
-    Parameters
-    ----------
-    data: 1-D array of float
-        The data to be analysed.
-    samplerate: float
-        Sampling rate of the data in Hertz.
-
-    OPTIONAL:
-    pw : float
-        peak width for peak detection in seconds.
-    cw : float
-        cut width for extracting snippets for clustering based on EOD shape
-    percentile: float
-        percentile for determining epsilon from knn distribution where k=minp
-    npc : int
-        number of PCs to use for PCA
-    minp : int
-        minimun number of point for core cluster (DBSCAN)
-    ngaus : int
-        maximun number of gaussians to fit for clustering on EOD hights
-    n_init: int
-        number of initializations for BayesianGaussianMixture method
-    m_iter: int
-        maximum number of iterations for BayesianGausssianMixture method
-        
-    Returns
-    -------
-    mean_eods: list of 2D arrays
-        For each detected fish the average of the EOD snippets. First column is time in seconds,
-        second column the mean eod, third column the standard error.
-    eod_times: list of 1D arrays
-        For each detected fish the times of EOD peaks in seconds.
-    """
-    
-    mean_eods, eod_times = [], []
-    
-    # extract peaks
-    idx_arr, idx_t_arr, h_arr, w_arr = extract_eod_times(data, pw*samplerate,cw*samplerate)
-
-    if len(idx_arr)>0:
-
-        # cluster on peaks
-        c_p = cluster(idx_arr,h_arr,w_arr,data,samplerate,cw,minp,percentile,npc,ngaus,n_init,m_iter) 
-
-        # cluster on troughs
-        c_t = cluster(idx_t_arr,h_arr,w_arr,data,samplerate,cw,minp,percentile,npc,ngaus,n_init,m_iter)
-
-        # merge peak and trough clusters
-        c, c_idx_arr = merge_clusters(c_p,c_t,idx_arr,idx_t_arr)
-
-        # remove noise from merged clusters
-        c = remove_noise_and_artefacts(data,c_idx_arr,w_arr,c,int(cw*samplerate))
-
-        # delete the moving fish
-        c = delete_moving_fish(c,c_idx_arr/samplerate,len(data)/samplerate, h_arr)
-
-        # extract mean eods
-        mean_eods, eod_times = find_window(data,c_idx_arr,w_arr,c,samplerate)
-    
-    return mean_eods, eod_times

--- a/thunderfish/pulse_tracker_helper.py
+++ b/thunderfish/pulse_tracker_helper.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def makeeventlist(main_event_positions,side_event_positions,data,event_width=20, min_width=2):
+def makeeventlist(main_event_positions, side_event_positions, data, event_width=20, min_width=2):
     """
     Generate array of events that might be EODs of a pulse-type fish, using the location of peaks and troughs,
     the data and an optional width of an supposed EOD-event.
@@ -16,7 +16,10 @@ def makeeventlist(main_event_positions,side_event_positions,data,event_width=20,
         side events in the data time series. The complimentary event to the main events.
     data: array of float
         The given data.
-    event_width: int or float, optional
+    event_width (optional): int
+        Maximum EOD width (in samples).
+    min_width (optional): int
+        Minimum EOD width (in samples).
 
     Returns
     -------
@@ -26,29 +29,31 @@ def makeeventlist(main_event_positions,side_event_positions,data,event_width=20,
                 x, y, height along the first axis, width and x of the most significant nearby trough.
 
     """
+
     mainfirst = int((min(main_event_positions[0],side_event_positions[0])<side_event_positions[0]))  # determines if there is a peak or through first. Evaluates to 1 if there is a peak first.
-    main_x = main_event_positions
+    
+    main_xp = main_event_positions
+    main_xt = np.zeros(len(main_event_positions))
     main_y = data[main_event_positions]
-    # empty placeholders, filled in the next step while iterating over the properties of single main
     main_h = np.zeros(len(main_event_positions))
     main_w = np.zeros(len(main_event_positions))
-    main_xt = np.zeros(len(main_event_positions))
 
     main_real = np.ones(len(main_event_positions))
     # iteration over the properties of the single main
-    for ind,(x, y, h, r, w, xt) in enumerate(np.nditer([main_x, main_y, main_h, main_real, main_w, main_xt], op_flags=[["readonly"],['readonly'],['readwrite'],['readwrite'],['readwrite'],['readwrite']])):
+    for ind, (xp, xt, y, h, w, r) in enumerate(np.nditer([main_xp, main_xt, main_y, main_h, main_w, main_real], op_flags=[["readonly"],['readwrite'],['readonly'],['readwrite'],['readwrite'],['readwrite']])):
         
         l_side_ind = ind - mainfirst
         r_side_ind = l_side_ind + 1
+
         try:
             r_side_x = side_event_positions[r_side_ind]
-            r_distance = r_side_x - x
+            r_distance = r_side_x - xp
             r_side_y = data[r_side_x]
         except:
             pass
         try:
             l_side_x = side_event_positions[l_side_ind]
-            l_distance = x - l_side_x
+            l_distance = xp - l_side_x
             l_side_y = data[l_side_x]
         except:
             pass # ignore left or rightmost events which throw IndexError
@@ -59,16 +64,16 @@ def makeeventlist(main_event_positions,side_event_positions,data,event_width=20,
             elif max((l_distance),(r_distance)) <= event_width:
                     h[...] = max(abs(y-l_side_y),abs(y-r_side_y))  #calculated using absolutes in case of for example troughs instead of peaks as main events 
                     w[...] = [l_distance,r_distance][np.argmax([abs(y-l_side_y),abs(y-r_side_y)])]
-                    xt[...] = x + [-l_distance,r_distance][np.argmax([abs(y-l_side_y),abs(y-r_side_y)])]
+                    xt[...] = xp + [-l_distance,r_distance][np.argmax([abs(y-l_side_y),abs(y-r_side_y)])]
             else:
                     if (l_distance)<(r_distance): # evaluated only when exactly one side event is out of reach of the event width. Then the closer event will be the correct event
                         h[...] = abs(y-l_side_y)
                         w[...] = l_distance
-                        xt[...] = x + -l_distance
+                        xt[...] = xp + -l_distance
                     else:
                         h[...] = abs(y-r_side_y)
                         w[...] = r_distance
-                        xt[...] = x + r_distance
+                        xt[...] = xp + r_distance
         # check corner cases
         elif l_side_ind == -1:
             if r_distance > event_width:
@@ -76,16 +81,16 @@ def makeeventlist(main_event_positions,side_event_positions,data,event_width=20,
             else:
                 h[...] = y-r_side_y
                 w[...] = r_distance
-                xt[...] = x + r_distance
+                xt[...] = xp + r_distance
         elif r_side_ind == len(side_event_positions):
             if l_distance> event_width:
                 r[...] = False
             else:
                 h[...] = y-l_side_y
                 w[...] = l_distance
-                xt[...] = x - l_distance
+                xt[...] = xp - l_distance
     # generate return array and discard all events that are not marked as real
-    EOD_events = np.array([main_x, main_y, main_h, main_w, main_xt], dtype = np.float)[:,main_real==1]
+    EOD_events = np.array([main_xp, main_xt, main_y, main_h, main_w])[:,main_real==1]
     return EOD_events
 
 def discardnearbyevents(event_locations, event_heights, min_distance):
@@ -118,6 +123,7 @@ def discardnearbyevents(event_locations, event_heights, min_distance):
     event_indices: array of int
         Indices of arrays which are not to be discarded
     """
+
     unchanged = False
     counter = 0
     event_indices = np.arange(0,len(event_locations)+1,1)
@@ -139,31 +145,30 @@ def discardnearbyevents(event_locations, event_heights, min_distance):
        if counter > 2000:
            print('Warning: unusual many discarding steps needed, unusually dense events')
            pass
-    return event_indices.astype('int'), event_locations, event_heights
+    return event_indices, event_locations, event_heights
 
-def discard_connecting_eods(pks, trs, hs, ws):
-    '''
+def discard_connecting_eods(x_peak, x_trough, hights, widths):
+    """
     If two detected EODs share the same closest trough, keep only the highest peak
 
-    Input
-    -----------
-    pks : list of ints
-        indices of EOD peaks
-    trs : list of ints
-        indices of EOD troughs
-    hs : list of floats
-        EOD hights
-    ws : list of ints
-        EOD widths
-
-    Output
+    Parameters
     ----------
-    pks, trs, hs, ws : lists of ints and floats
+    x_peak: list of ints
+        Indices of EOD peaks.
+    x_trough: list of ints
+        Indices of EOD troughs.
+    hights: list of floats
+        EOD hights.
+    widths: list of ints
+        EOD widths.
+
+    Returns
+    -------
+    x_peak, x_trough, hights, widths : lists of ints and floats
         EOD location and features of the non-discarded EODs
-    '''
-    keep_idxs = np.ones(len(pks))
-    for tr in np.unique(trs):
-        if len(trs[trs==tr])>1:
-            #keep only highest one.
-            keep_idxs[np.where(trs==tr)[0][np.argmin(hs[trs==tr])]] = 0
-    return pks[keep_idxs.astype('bool')].astype('int'), trs[keep_idxs.astype('bool')].astype('int'), hs[keep_idxs.astype('bool')], ws[keep_idxs.astype('bool')]
+    """
+    keep_idxs = np.ones(len(x_peak), dtype='bool')
+    for tr in np.unique(x_trough):
+        if len(x_trough[x_trough==tr]) > 1:
+            keep_idxs[np.where(x_trough==tr)[0][np.argmin(hights[x_trough==tr])]] = 0
+    return x_peak[keep_idxs], x_trough[keep_idxs], hights[keep_idxs], widths[keep_idxs]


### PR DESCRIPTION
… hight.

Also added another return to the function, which is the ratio between pulse width and interpulse width. Values > 0.1 are either wavefish or pulsefish of which the peak and/or trough has not been correctly detected. this often happens with small amplitudes. I could lower peak detection threshold but this also increases computation time significantly,